### PR TITLE
Fix: Remove unused code

### DIFF
--- a/ch11/11.4/nodebird/routes/auth.test.js
+++ b/ch11/11.4/nodebird/routes/auth.test.js
@@ -102,7 +102,6 @@ describe('GET /logout', () => {
   });
 
   test('로그아웃 수행', async (done) => {
-    const message = encodeURIComponent('비밀번호가 일치하지 않습니다.');
     agent
       .get('/auth/logout')
       .expect('Location', `/`)


### PR DESCRIPTION
 오탈자는 아니지만 로그아웃 수행 테스트 시 사용하지 않는 message 선언이 있습니다.
'비밀번호 틀림' 테스트에서 사용하는 메시지인데 잘못 들어간 것 같네요.