### PR TITLE
Update spawn.js

### DIFF
--- a/ch3/3.5/spawn.js
+++ b/ch3/3.5/spawn.js
@@ -1,6 +1,8 @@
 const spawn = require('child_process').spawn;
+const path = require('path');
 
-const process = spawn('python', ['test.py']);
+const pythonCodePath = path.join(__dirname, 'test.py');
+const process = spawn('python', [pythonCodePath]);
 
 process.stdout.on('data', function(data) {
   console.log(data.toString());


### PR DESCRIPTION
안녕하세요, 제로초님.
블로그, 자바스크립트 책, 노드 책, 유튜브 모두 잘 보고 있습니다!

노드 책(2판)에 있는 코드를 따라 치다가 든 생각인데요,
child_process.spawn으로 파이썬 코드를 실행할 때,
아예 파이썬 파일의 경로 자체를 넘겨주는 건 어떨까요?

노드 파일을 실행할 때
어떤 사람은 프로젝트 최상단에서 node [경로/파일명] 하고,
예: C:\pj\nodejs-book>node C:\pj\nodejs-book\ch3\3.5\spawn.js

어떤 사람은 해당 파일이 있는 폴더에서 node [파일명] 하는데,
예:  C:\pj\nodejs-book\ch3\3.5>node spawn

spawn에 파이썬 파일의 경로 자체를 넘겨주는 걸로 수정한다면
프로젝트 최상단에서 node [경로/파일명] 했을 때 아래와 같은 에러 메시지가 나오는 것을 막을 수 있어서요.
python: can't open file 'C:\\pj\\nodejs-book\\test.py': [Errno 2] No such file or directory

굉장히 사소하지만 혹시나 해서 PR 해봅니다. 늘 감사합니다!